### PR TITLE
fix: Update engagement evaluation logic to reflect new emotional stat…

### DIFF
--- a/client/public/scripts/instructor.js
+++ b/client/public/scripts/instructor.js
@@ -195,8 +195,8 @@ function evaluateEngagement(record, mode) {
     const poseExists = pose !== 'Not Detected';
     const handNotRaised = record.hand_text === 'Not Raised';
     const emotion = record.emotion_text;
-    const emotionOK = !['angry', 'sad', 'fear'].includes(emotion);
-    const emotionNeutralOrFocused = ['neutral', 'focused'].includes(emotion);
+    const emotionOK = !['Surprise', 'Sad', 'Happy'].includes(emotion);
+    const emotionNeutralOrFocused = ['neutral', 'Sad'].includes(emotion);
   
     if (mode === 'break') return true;
   
@@ -204,8 +204,8 @@ function evaluateEngagement(record, mode) {
       return awake && notYawning && gazeCenter && poseGoodTeach && emotionOK;
     }
   
-    if (mode === 'discussion') {
-      return awake && notYawning && poseExists && emotion !== 'angry';
+        if (mode === 'discussion') {
+        return awake && notYawning && poseExists && emotion !== 'Sad';
     }
   
     if (mode === 'exam') {
@@ -838,6 +838,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         time: lectureTime
                     };
                     activeLectureCode = data.lecture_code; // Update simple code variable too
+                    window.setClassMode('teaching');
 
                     // Show/Hide recording section based on 'setActive'
                     if (setActive) {


### PR DESCRIPTION
This pull request modifies the `evaluateEngagement` function and adds functionality to the `DOMContentLoaded` event listener in `client/public/scripts/instructor.js`. The changes focus on refining engagement evaluation logic and introducing a new method to set the class mode.

### Engagement evaluation logic updates:

* Updated the `emotionOK` and `emotionNeutralOrFocused` conditions to reflect new criteria for acceptable emotions. Specifically, "Surprise," "Sad," and "Happy" are now excluded from `emotionOK`, and "Sad" is added to `emotionNeutralOrFocused`.
* Adjusted the `discussion` mode logic to exclude "Sad" as an acceptable emotion instead of "angry."

### Event listener enhancement:

* Added a call to `window.setClassMode('teaching')` within the `DOMContentLoaded` event listener to set the class mode to "teaching" when the lecture is active.…es and improve discussion mode handling